### PR TITLE
extramana: Fix bar showing when values are not available

### DIFF
--- a/unitframe/extramana.lua
+++ b/unitframe/extramana.lua
@@ -51,6 +51,9 @@
     end
 
     local OnEvent = function()
+        if event == 'PLAYER_AURAS_CHANGED' then
+            if not PlayerFrame.ExtraManaBar:IsShown() then return end
+        end
         if  f.loaded and UnitPowerType'player' ~= 0 then
             PlayerFrame.ExtraManaBar:Show()
         else

--- a/unitframe/extramana.lua
+++ b/unitframe/extramana.lua
@@ -33,21 +33,12 @@
     modSkinPadding(PlayerFrame.ExtraManaBar, 2, 2, 2, 2, 2, 2, 2, 2)
     modSkinColor(PlayerFrame.ExtraManaBar, .2, .2, .2)
 
-    local GetValue = function()
-        local v = DruidManaLib:GetMana()
+    local OnUpdate = function()
+        DruidManaLib:MaxManaScript()
+        local v, max = DruidManaLib:GetMana()
+        PlayerFrame.ExtraManaBar:SetMinMaxValues(0, max)
         PlayerFrame.ExtraManaBar:SetValue(v)
         PlayerFrame.ExtraManaBar.Text:SetText(true_format(v))
-    end
-
-    local GetMaxValue = function()
-    	DruidManaLib:MaxManaScript()
-    	local _, max = DruidManaLib:GetMana()
-    	PlayerFrame.ExtraManaBar:SetMinMaxValues(0, max)
-    end
-
-    local OnUpdate = function()
-        GetMaxValue()
-	    GetValue()
     end
 
     local OnEvent = function()


### PR DESCRIPTION
~~Shapeshifting cost is subtracted, then subtracted again when the PLAYER_AURAS_CHANGED event is fired.~~

PLAYER_AURAS_CHANGED is showing the bar when values are not available.

Steps to reproduce:

1. Shapeshift into Cat Form
~~2. Cast Prowl~~
~~-- issue2, cont...~~
3.  ReloadUI
4. Cast Tiger's Fury

Edit: Removing shapeshifting cost commit from this pull request. It looks like no shapeshifting cost is subtracted on the Elysium server (with or without any of these changes).